### PR TITLE
:sparkle: Save favorite state

### DIFF
--- a/src/elements/favourite-talk.js
+++ b/src/elements/favourite-talk.js
@@ -3,12 +3,12 @@ import { sharedStyles } from '../shared-styles';
 import '@material/mwc-icon-button-toggle';
 
 /**
- * `favorite-talk`
+ * `favourite-talk`
  * Handle favouring a talk
  *
  * @customElement
  */
-export class FavoriteTalk extends LitElement {
+export class FavouriteTalk extends LitElement {
   /** Defines the elements styles */
   static get styles() {
     const style = css`
@@ -31,10 +31,10 @@ export class FavoriteTalk extends LitElement {
   render() {
     return html`
         <mwc-icon-button-toggle
-            ?on=${this.isFavorited}
+            ?on=${this.isFavourited}
             onIcon="favorite"
             offIcon="favorite_border"
-            label="Favorite Talk Button"
+            label="Favourite Talk Button"
             @MDCIconButtonToggle:change="${this.toggle}"></mwc-icon-button-toggle>
     `;
   }
@@ -45,7 +45,7 @@ export class FavoriteTalk extends LitElement {
       /** The talk information */
       talk: { type: Object },
       /** If the talk is a favourite */
-      isFavorited: { type: Boolean },
+      isFavourited: { type: Boolean },
     };
   }
 
@@ -53,7 +53,7 @@ export class FavoriteTalk extends LitElement {
   constructor() {
     super();
     this.talk = {};
-    this.isFavorited = false;
+    this.isFavourited = false;
   }
 
   /**
@@ -61,7 +61,7 @@ export class FavoriteTalk extends LitElement {
      * @param {CustomEvent} event
      */
   toggle(event) {
-    const eventName = (event.detail.isOn ? 'talk-favorited' : 'talk-unfavorited');
+    const eventName = (event.detail.isOn ? 'talk-favourited' : 'talk-unfavourited');
     this.dispatchEvent(new CustomEvent(eventName, {
       detail: this.talk.id,
       bubbles: true,
@@ -70,4 +70,4 @@ export class FavoriteTalk extends LitElement {
   }
 }
 
-window.customElements.define('favorite-talk', FavoriteTalk);
+window.customElements.define('favourite-talk', FavouriteTalk);

--- a/src/elements/favourite-talk.test.js
+++ b/src/elements/favourite-talk.test.js
@@ -1,11 +1,11 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
-import './favorite-talk';
+import './favourite-talk';
 
-describe('favorite-talk tests', () => {
+describe('favourite-talk tests', () => {
   let node;
   beforeEach(async () => {
-    node = document.createElement('favorite-talk');
+    node = document.createElement('favourite-talk');
     node.talk = {
       id: '1234567890',
     };
@@ -21,7 +21,7 @@ describe('favorite-talk tests', () => {
     const button = node.shadowRoot.querySelector('mwc-icon-button-toggle');
     expect(button.onIcon).to.equal('favorite');
     expect(button.offIcon).to.equal('favorite_border');
-    expect(button.label).to.equal('Favorite Talk Button');
+    expect(button.label).to.equal('Favourite Talk Button');
   });
 
   it('should be off by default', () => {
@@ -29,16 +29,16 @@ describe('favorite-talk tests', () => {
     expect(button.on).to.be.false;
   });
 
-  it('should be on if favorited', async () => {
-    node.isFavorited = true;
+  it('should be on if favourited', async () => {
+    node.isFavourited = true;
     await node.updateComplete;
     const button = node.shadowRoot.querySelector('mwc-icon-button-toggle');
     expect(button.on).to.be.true;
   });
 
-  it('should fire an favorited event when clicked', async () => {
+  it('should fire an favourited event when clicked', async () => {
     const spy = sinon.spy();
-    node.addEventListener('talk-favorited', spy);
+    node.addEventListener('talk-favourited', spy);
 
     const toggle = node.shadowRoot.querySelector('mwc-icon-button-toggle');
     const button = toggle.shadowRoot.querySelector('button');
@@ -51,12 +51,12 @@ describe('favorite-talk tests', () => {
     expect(toggle.on).to.be.true;
   });
 
-  it('should fire an unfavorited event when clicked and already favorited', async () => {
-    node.isFavorited = true;
+  it('should fire an unfavourited event when clicked and already favourited', async () => {
+    node.isFavourited = true;
     await node.updateComplete;
 
     const spy = sinon.spy();
-    node.addEventListener('talk-unfavorited', spy);
+    node.addEventListener('talk-unfavourited', spy);
 
     const toggle = node.shadowRoot.querySelector('mwc-icon-button-toggle');
     const button = toggle.shadowRoot.querySelector('button');

--- a/src/elements/storage.js
+++ b/src/elements/storage.js
@@ -1,0 +1,29 @@
+import { Plugins } from '@capacitor/core';
+
+const { Storage } = Plugins;
+
+/**
+ * Load any existing favourite talks from storage
+ * @return {Array} any favourited talks
+ */
+export const loadFavouriteTalks = async () => {
+  const existing = await Storage.get({ key: 'favourites' });
+  if (existing.value && existing.value !== 'undefined') {
+    return JSON.parse(existing.value);
+  }
+  return [];
+};
+
+/**
+ * Save favourite talks to storage
+ * @param {Array} favouriteTalks the list of favourited talks
+ * @return {Promise} the pending save
+ */
+export const saveFavouriteTalks = async favouriteTalks => Storage.set({ key: 'favourites', value: JSON.stringify(favouriteTalks) });
+
+
+/**
+ * Clear favourited talks in storage
+ * @return {Promise} the pending save
+ */
+export const clearFavouriteTalks = async () => Storage.remove({ key: 'favourites' });

--- a/src/elements/storage.test.js
+++ b/src/elements/storage.test.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { loadFavouriteTalks, saveFavouriteTalks, clearFavouriteTalks } from './storage';
+
+describe('storage tests', () => {
+  describe('clear favourite talks', () => {
+    it('should remove any favourite talks', async () => {
+      await saveFavouriteTalks(['1', '3']);
+      await clearFavouriteTalks();
+      const result = await loadFavouriteTalks();
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('load favourite talks', () => {
+    afterEach(async () => {
+      await clearFavouriteTalks();
+    });
+
+    it('should parse any existing talks in storage', async () => {
+      await saveFavouriteTalks(['1', '2']);
+      const result = await loadFavouriteTalks();
+      expect(result).to.deep.equal(['1', '2']);
+    });
+
+    it('should handle no existing talks', async () => {
+      const result = await loadFavouriteTalks();
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should handle undefined saved value', async () => {
+      await saveFavouriteTalks(undefined);
+      const result = await loadFavouriteTalks();
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('save favourite talks', () => {
+    afterEach(async () => {
+      await clearFavouriteTalks();
+    });
+
+    it('should save the list of talks', async () => {
+      await saveFavouriteTalks(['1', '3']);
+      const result = await loadFavouriteTalks();
+      expect(result).to.deep.equal(['1', '3']);
+    });
+  });
+});

--- a/src/elements/talk-overview.js
+++ b/src/elements/talk-overview.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from 'lit-element/lit-element';
 import { sharedStyles } from '../shared-styles';
 import { formatDate } from './formatters';
-import './favorite-talk';
+import './favourite-talk';
 
 /**
  * `talk-overview`
@@ -42,7 +42,7 @@ export class TalkOverview extends LitElement {
             </div>
             <div class="content">${this.talk.description.substr(0, 200)}...</div>
             <div class="footer">
-                <favorite-talk ?isFavorited=${this.isFavorited} .talk=${this.talk}></favorite-talk>
+                <favourite-talk ?isFavourited=${this.isFavourited} .talk=${this.talk}></favourite-talk>
             </div>
     `;
   }
@@ -53,7 +53,7 @@ export class TalkOverview extends LitElement {
       /** The talk information */
       talk: { type: Object },
       /** If the talk is a favourite */
-      isFavorited: { type: Boolean },
+      isFavourited: { type: Boolean },
     };
   }
 
@@ -61,7 +61,7 @@ export class TalkOverview extends LitElement {
   constructor() {
     super();
     this.talk = {};
-    this.isFavorited = false;
+    this.isFavourited = false;
   }
 }
 

--- a/src/elements/talk-overview.test.js
+++ b/src/elements/talk-overview.test.js
@@ -54,11 +54,11 @@ describe('talk-overview tests', () => {
     expect(content.textContent).to.equal('Spicy jalapeno bacon ipsum dolor amet spare ribs venison cow short ribs t-bone ground round boudin alcatra. Shankle fatback chicken salami, pancetta corned beef meatloaf. Tongue fatback chuck jerky sh...');
   });
 
-  it('should pass talk and favorited information into the favorite-talk element', async () => {
-    node.isFavorited = true;
+  it('should pass talk and favourited information into the favourite-talk element', async () => {
+    node.isFavourited = true;
     await node.updateComplete;
-    const favorite = node.shadowRoot.querySelector('favorite-talk');
-    expect(favorite.isFavorited).to.be.true;
-    expect(favorite.talk).to.deep.equal(node.talk);
+    const favourite = node.shadowRoot.querySelector('favourite-talk');
+    expect(favourite.isFavourited).to.be.true;
+    expect(favourite.talk).to.deep.equal(node.talk);
   });
 });

--- a/src/pages/favourite-talks-page.js
+++ b/src/pages/favourite-talks-page.js
@@ -3,7 +3,7 @@ import { sharedStyles } from '../shared-styles';
 
 /**
  * `favourite-talks-page`
- * Page to display favorited talks
+ * Page to display favourited talks
  *
  * @customElement
  */
@@ -30,13 +30,13 @@ export class FavouriteTalksPage extends LitElement {
  */
   render() {
     return html`
-        <h2>Favorite Talks</h2>
+        <h2>Favourite Talks</h2>
         <loading-display ?hidden=${!this.isLoading} label=""></loading-display>
         <error-display ?hidden=${!this.isError} label=""></error-display>
         <div class="list">
           ${this.talks
-    .filter(talk => this.favoriteTalks.indexOf(talk.id) > -1)
-    .map(talk => html`<talk-overview .talk=${talk} isfavorite></talk-overview>`)}
+    .filter(talk => this.favouriteTalks.indexOf(talk.id) > -1)
+    .map(talk => html`<talk-overview .talk=${talk} isfavourite></talk-overview>`)}
         </div>
     `;
   }
@@ -46,8 +46,8 @@ export class FavouriteTalksPage extends LitElement {
     return {
       /** The list of talks */
       talks: { type: Array },
-      /** The list of favorited talks */
-      favoriteTalks: { type: Array },
+      /** The list of favourited talks */
+      favouriteTalks: { type: Array },
       /** If the list of talks is loading */
       isLoading: { type: Boolean },
       /** If the list of talks has errored */
@@ -61,7 +61,7 @@ export class FavouriteTalksPage extends LitElement {
     this.isLoading = false;
     this.isError = false;
     this.talks = [];
-    this.favoriteTalks = [];
+    this.favouriteTalks = [];
   }
 }
 

--- a/src/pages/favourite-talks-page.test.js
+++ b/src/pages/favourite-talks-page.test.js
@@ -13,14 +13,14 @@ describe('favourite-talks-page tests', () => {
     node.remove();
   });
 
-  it('should render only the list of favorited talks', async () => {
+  it('should render only the list of favourited talks', async () => {
     node.talks = [
       { id: '1' },
       { id: '2' },
       { id: '3' },
       { id: '4' },
     ];
-    node.favoriteTalks = ['1', '3'];
+    node.favouriteTalks = ['1', '3'];
     await node.updateComplete;
 
     const talks = node.shadowRoot.querySelectorAll('talk-overview');

--- a/src/pages/home-page.js
+++ b/src/pages/home-page.js
@@ -63,7 +63,7 @@ export class HomePage extends LitElement {
         <loading-display ?hidden=${!this.isLoading} label=""></loading-display>
         <error-display ?hidden=${!this.isError} label=""></error-display>
         <div class="list">
-          ${this.talks.map(talk => html`<talk-overview .talk=${talk} ?isFavorite=${this.isTalkFavorited(talk)}></talk-overview>`)}
+          ${this.talks.map(talk => html`<talk-overview .talk=${talk} ?isFavourite=${this.isTalkFavourited(talk)}></talk-overview>`)}
         </div>
       </div>
     `;
@@ -74,8 +74,8 @@ export class HomePage extends LitElement {
     return {
       /** The list of talks */
       talks: { type: Array },
-      /** The list of favorited talks */
-      favoriteTalks: { type: Array },
+      /** The list of favourited talks */
+      favouriteTalks: { type: Array },
       /** If the list of talks is loading */
       isLoading: { type: Boolean },
       /** If the list of talks has errored */
@@ -89,16 +89,16 @@ export class HomePage extends LitElement {
     this.isLoading = false;
     this.isError = false;
     this.talks = [];
-    this.favoriteTalks = [];
+    this.favouriteTalks = [];
   }
 
   /**
-   * Checks the list of favorited talk ids to see if a talk is favoured
+   * Checks the list of favourited talk ids to see if a talk is favoured
    * @param {Object} talk the talk info
-   * @return {Boolean} if the talk is in the favorite list
+   * @return {Boolean} if the talk is in the favourite list
    */
-  isTalkFavorited(talk) {
-    return this.favoriteTalks.indexOf(talk.id) > -1;
+  isTalkFavourited(talk) {
+    return this.favouriteTalks.indexOf(talk.id) > -1;
   }
 }
 

--- a/src/pages/home-page.test.js
+++ b/src/pages/home-page.test.js
@@ -57,14 +57,14 @@ describe('home-page tests', () => {
     expect(error.hidden).to.be.false;
   });
 
-  it('should check if a talk is favorited', async () => {
-    node.favoriteTalks = ['1'];
+  it('should check if a talk is favourited', async () => {
+    node.favouriteTalks = ['1'];
     await node.updateComplete;
 
-    const expectedTrue = node.isTalkFavorited({ id: '1' });
+    const expectedTrue = node.isTalkFavourited({ id: '1' });
     expect(expectedTrue).to.be.true;
 
-    const expectedFalse = node.isTalkFavorited({ id: '2' });
+    const expectedFalse = node.isTalkFavourited({ id: '2' });
     expect(expectedFalse).to.be.false;
   });
 });


### PR DESCRIPTION
* Add storage layer to handle saving, removing, loading favorite talks
* Load favorited talks on app load
* Save favorite talks when changed
* Handle favorite and unfavorite talk events and update favorite talks list accordingly

Closes TheDataShed/leeds-digital-festival-app#13